### PR TITLE
Allow no space after ':' in request headers

### DIFF
--- a/curlreq.go
+++ b/curlreq.go
@@ -193,5 +193,5 @@ func isURL(u string) bool {
 
 func parseField(a string) (string, string) {
 	i := strings.Index(a, ":")
-	return strings.TrimSpace(a[0:i]), strings.TrimSpace(a[i+2:])
+	return strings.TrimSpace(a[0:i]), strings.TrimSpace(a[i+1:])
 }


### PR DESCRIPTION
How about allowing no space after ":" in request headers?

ex. `curl https://httpbin.org/json -H "accept:application/json"`
